### PR TITLE
Add GitHub user search and repository list display

### DIFF
--- a/src/@types/repo.d.ts
+++ b/src/@types/repo.d.ts
@@ -1,0 +1,7 @@
+export interface repo {
+  id: number
+  full_name: string
+  description: string
+  private: boolean
+  html_url: string
+}

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,7 +1,13 @@
 import styles from './input.module.css';
 
-export const Input = () => {
-  return (
-    <input type="text" name={'user'} placeholder={'@username'} className={styles.input} />
-  )
+interface InputProps {
+  value: string,
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
 }
+
+export const Input = ({ value, onChange }: InputProps) => {
+  return (
+    <input type="text" name={'user'} placeholder={'@username'} className={styles.input}
+           value={value} onChange={onChange}/>
+  );
+};

--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -1,0 +1,3 @@
+export const Loading = () => {
+  return <div>Loading...</div>;
+}

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -1,14 +1,40 @@
 import styles from './profile.module.css';
+import { JSX } from 'react';
 
-export const Profile = () => {
+/**
+ * Interface representing the properties for a user profile component.
+ * I don't really like creating nested props like this, but as this is a simple app, I felt
+ * no need to create a type definition file for such a simple implementation.
+ *
+ * @interface ProfileProps
+ * @property {Object} userData - An object containing information about the user.
+ * @property {string} userData.name - The full name of the user.
+ * @property {string} userData.login - The username or login identifier of the user.
+ * @property {string} userData.avatar_url - The URL of the user's avatar image.
+ * @property {string} userData.bio - A brief biography or description of the user.
+ */
+interface ProfileProps {
+  userData: {
+    name: string;
+    login: string;
+    avatar_url: string | undefined;
+    bio: string;
+  };
+}
+
+/**
+ * A simple profile card containing user's Name, UserName, Avatar and Profile, fetched from
+ * their Github Profile.
+ */
+export const Profile = ({ userData }: ProfileProps): JSX.Element => {
   return (
     <div className={styles.profileContainer}>
-      <img src="https://avatars.githubusercontent.com/u/163813?v=4" alt="Profile" className={styles.profilePicture}/>
+      <img src={userData.avatar_url} alt="Profile" className={styles.profilePicture}/>
       <div className={styles.name}>
-        <h2 className={styles.profile_name}>Placeholder name</h2>
-        <p className={styles.profile_handler}>@username</p>
-        <p className={styles.profile_description}>Placeholder description</p>
+        <h2 className={styles.profile_name}>{userData.name}</h2>
+        <p className={styles.profile_handler}>@{userData.login}</p>
+        <p className={styles.profile_description}>{userData.bio}</p>
       </div>
     </div>
-  )
-}
+  );
+};

--- a/src/components/Profile/profile.module.css
+++ b/src/components/Profile/profile.module.css
@@ -1,5 +1,4 @@
 .profileContainer{
-    border: 1px solid white;
     display: flex;
     align-self: center;
     width: 100%;

--- a/src/components/RepoList/index.tsx
+++ b/src/components/RepoList/index.tsx
@@ -1,9 +1,10 @@
+import styles from './repolist.module.css'
 import { RepoListItem } from '../RepoListItem';
 
 export const RepoList = () => {
   return (
     <div>
-      <h3>Repositórios</h3>
+      <h3 className={styles.title}>Repositórios</h3>
       <ul>
         <RepoListItem repoName={'Teste'} repoUrl={'https://google.com.br'}
                       repoDescription={'This is a test'}/>

--- a/src/components/RepoList/index.tsx
+++ b/src/components/RepoList/index.tsx
@@ -1,0 +1,19 @@
+import { RepoListItem } from '../RepoListItem';
+
+export const RepoList = () => {
+  return (
+    <div>
+      <h3>Repositórios</h3>
+      <ul>
+        <RepoListItem repoName={'Teste'} repoUrl={'https://google.com.br'}
+                      repoDescription={'This is a test'}/>
+        <RepoListItem repoName={'Teste'} repoUrl={'https://google.com.br'}
+                      repoDescription={'This is a test'}/>
+        <RepoListItem repoName={'Teste'} repoUrl={'https://google.com.br'}
+                      repoDescription={'This is a test'}/>
+        <RepoListItem repoName={'Teste'} repoUrl={'https://google.com.br'}
+                      repoDescription={'This is a test'}/>
+      </ul>
+    </div>
+  );
+};

--- a/src/components/RepoList/index.tsx
+++ b/src/components/RepoList/index.tsx
@@ -1,19 +1,20 @@
 import styles from './repolist.module.css'
 import { RepoListItem } from '../RepoListItem';
+import { repo } from '../../@types/repo';
 
-export const RepoList = () => {
+interface RepoListProps {
+  repos: repo[];
+}
+
+export const RepoList = ({repos}:RepoListProps) => {
   return (
     <div>
       <h3 className={styles.title}>Repositórios</h3>
       <ul>
-        <RepoListItem repoName={'Teste'} repoUrl={'https://google.com.br'}
-                      repoDescription={'This is a test'}/>
-        <RepoListItem repoName={'Teste'} repoUrl={'https://google.com.br'}
-                      repoDescription={'This is a test'}/>
-        <RepoListItem repoName={'Teste'} repoUrl={'https://google.com.br'}
-                      repoDescription={'This is a test'}/>
-        <RepoListItem repoName={'Teste'} repoUrl={'https://google.com.br'}
-                      repoDescription={'This is a test'}/>
+        {repos.map((repo) => (
+          <RepoListItem key={repo.id} repoName={repo.full_name} repoUrl={repo.html_url}
+                        repoDescription={repo.description} isPrivate={repo.private}/>
+        ))}
       </ul>
     </div>
   );

--- a/src/components/RepoList/repolist.module.css
+++ b/src/components/RepoList/repolist.module.css
@@ -1,0 +1,4 @@
+.title{
+    text-align: center;
+    font-size: 1.5rem;
+}

--- a/src/components/RepoListItem/index.tsx
+++ b/src/components/RepoListItem/index.tsx
@@ -6,11 +6,17 @@ interface RepoListItemProps {
   repoUrl: string,
 }
 
-export const RepoListItem = ({repoName, repoDescription, repoUrl} : RepoListItemProps) => {
+export const RepoListItem = ({ repoName, repoDescription, repoUrl }: RepoListItemProps) => {
   return (
-    <li className={styles.item}>
-      <h4>{repoName}</h4> - <a href={repoUrl}>🔗</a>
-      <p>{repoDescription}</p>
-    </li>
-  )
-}
+    <>
+      <li className={styles.item}>
+        <div>
+          <h4 className={styles.repoName}>{repoName}</h4>{" "}
+          <a href={repoUrl} target={"_blank"} rel="noreferrer noopener" className={styles.repoUrl}>🔗</a>
+        </div>
+        <p className={styles.repoDescription}>{repoDescription}</p>
+      </li>
+      <hr/>
+    </>
+  );
+};

--- a/src/components/RepoListItem/index.tsx
+++ b/src/components/RepoListItem/index.tsx
@@ -1,0 +1,16 @@
+import styles from './repoListItem.module.css';
+
+interface RepoListItemProps {
+  repoName: string,
+  repoDescription: string,
+  repoUrl: string,
+}
+
+export const RepoListItem = ({repoName, repoDescription, repoUrl} : RepoListItemProps) => {
+  return (
+    <li className={styles.item}>
+      <h4>{repoName}</h4> - <a href={repoUrl}>🔗</a>
+      <p>{repoDescription}</p>
+    </li>
+  )
+}

--- a/src/components/RepoListItem/index.tsx
+++ b/src/components/RepoListItem/index.tsx
@@ -4,17 +4,20 @@ interface RepoListItemProps {
   repoName: string,
   repoDescription: string,
   repoUrl: string,
+  isPrivate: boolean,
 }
 
-export const RepoListItem = ({ repoName, repoDescription, repoUrl }: RepoListItemProps) => {
+export const RepoListItem = ({ repoName, repoDescription, isPrivate, repoUrl }: RepoListItemProps) => {
   return (
     <>
       <li className={styles.item}>
         <div>
           <h4 className={styles.repoName}>{repoName}</h4>{" "}
+          {isPrivate ? <p>🔒</p> : null}
           <a href={repoUrl} target={"_blank"} rel="noreferrer noopener" className={styles.repoUrl}>🔗</a>
         </div>
-        <p className={styles.repoDescription}>{repoDescription}</p>
+        <p className={styles.repoDescription}>{repoDescription === null ? "O repositório não" +
+          " possui descrição." : repoDescription}</p>
       </li>
       <hr/>
     </>

--- a/src/components/RepoListItem/repolistitem.module.css
+++ b/src/components/RepoListItem/repolistitem.module.css
@@ -1,0 +1,3 @@
+.item {
+    list-style: none;
+}

--- a/src/components/RepoListItem/repolistitem.module.css
+++ b/src/components/RepoListItem/repolistitem.module.css
@@ -1,3 +1,19 @@
 .item {
     list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+    margin-block: 1rem;
+}
+
+.repoName{
+    display: inline;
+    color: #539BF5;
+}
+.repoUrl{
+    text-decoration: none;
+}
+.repoDescription{
+    color: #999999;
+    font-size: 0.75rem;
 }

--- a/src/pages/Home/home.module.css
+++ b/src/pages/Home/home.module.css
@@ -15,7 +15,6 @@
     margin-top: 0.625rem;
     padding-inline: 0.5rem;
     gap: 0.625rem;
-    border: 1px solid white;
 }
 
 .search{
@@ -29,5 +28,9 @@
 @media (width <= 620px) {
     .search {
         flex-direction: column;
+    }
+
+    .background{
+        display: none;
     }
 }

--- a/src/pages/Home/home.module.css
+++ b/src/pages/Home/home.module.css
@@ -23,7 +23,6 @@
     justify-content: flex-end;
     width: 100%;
     gap: 0.5rem;
-    padding-right: 0.625rem;
 
 }
 

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -5,12 +5,62 @@ import { Input } from '../../components/Input';
 import { Button } from '../../components/Button';
 import { Profile } from '../../components/Profile';
 import { RepoList } from '../../components/RepoList';
+import { useEffect, useState } from 'react';
+import { Loading } from '../../components/Loading';
+
+interface userDataProps {
+  login: string,
+  name: string
+  avatar_url: string | undefined,
+  bio: string,
+}
 
 function App() {
+  const [userInput, setUserInput] = useState<string>('');
+  const [userData, setUserData] = useState<userDataProps>(
+    { login: "", name: "", avatar_url: undefined, bio: "" });
+  const [userDataError, setUserDataError] = useState<boolean>(true);
+  const [isLoading, setIsLoading] = useState(false);
 
-  const handleClick = () => {
-    console.log('click');
+  const GITHUB_API_URL = 'https://api.github.com/users';
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setUserInput(e.target.value);
   };
+
+  const handleClick = async () => {
+    setIsLoading(true);
+
+    try {
+      const userRes = await fetch(`${GITHUB_API_URL}/${userInput}`);
+      if (!userRes.ok) {
+        setUserDataError(true);
+        setIsLoading(false);
+        return;
+      }
+      }
+
+      const jsonUserRes = await userRes.json();
+      setUserData({
+        login: jsonUserRes.login,
+        name: jsonUserRes.name,
+        avatar_url: jsonUserRes.avatar_url,
+        bio: jsonUserRes.bio,
+      });
+      setUserDataError(false);
+
+    } catch (e) {
+      setUserDataError(true);
+      console.error('Fetching error:', e);
+
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    console.log(userData);
+  }, [userData]);
 
   return (
     <>
@@ -19,12 +69,27 @@ function App() {
         <img src={github} alt="Github logo" className={styles.background}/>
         <div className={styles.info}>
           <div className={styles.search}>
-            <Input/>
+            <Input value={userInput} onChange={handleChange}/>
             <Button onClick={handleClick}/>
           </div>
-          <Profile />
-          <hr />
-          <RepoList />
+
+          {isLoading && (
+            <>
+              <Loading/>
+              <hr/>
+            </>
+          )}
+
+          {!userDataError && !isLoading &&
+            (
+              <>
+                <Profile userData={userData}/>
+                <hr/>
+              </>
+            )
+          }
+
+          <RepoList/>
         </div>
       </main>
     </>

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -3,16 +3,13 @@ import { Header } from '../../components/Header';
 import styles from './home.module.css';
 import { Input } from '../../components/Input';
 import { Button } from '../../components/Button';
-import { useState } from 'react';
 import { Profile } from '../../components/Profile';
 import { RepoList } from '../../components/RepoList';
 
 function App() {
-  const [counter, setCounter] = useState<number>(0);
 
   const handleClick = () => {
     console.log('click');
-    setCounter(counter + 1);
   };
 
   return (
@@ -25,7 +22,6 @@ function App() {
             <Input/>
             <Button onClick={handleClick}/>
           </div>
-          <p>The 'search' button was clicked {counter} times.</p>
           <Profile />
           <hr />
           <RepoList />

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -5,8 +5,9 @@ import { Input } from '../../components/Input';
 import { Button } from '../../components/Button';
 import { Profile } from '../../components/Profile';
 import { RepoList } from '../../components/RepoList';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Loading } from '../../components/Loading';
+import { repo } from '../../@types/repo';
 
 interface userDataProps {
   login: string,
@@ -20,6 +21,8 @@ function App() {
   const [userData, setUserData] = useState<userDataProps>(
     { login: "", name: "", avatar_url: undefined, bio: "" });
   const [userDataError, setUserDataError] = useState<boolean>(true);
+  const [userReposError, setUserReposError] = useState<boolean>(true);
+  const [repoList, setRepoList] = useState<repo[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
   const GITHUB_API_URL = 'https://api.github.com/users';
@@ -38,9 +41,43 @@ function App() {
         setIsLoading(false);
         return;
       }
+      const repoRes = await fetch(`${GITHUB_API_URL}/${userInput}/repos?sort=updated`);
+
+      if (!repoRes.ok) {
+        setUserDataError(true);
+        setIsLoading(false);
+        return;
       }
 
       const jsonUserRes = await userRes.json();
+      const jsonReposRes = await repoRes.json();
+
+      /**
+       * Represents the mapping of repository data fetched from a JSON response to a specific structure.
+       * Each repository object is transformed to include selected properties relevant for further use.
+       * <hr/>
+       * I know that suppressing this `any` warning is a bad practice, but to fix it I would
+       * need to create a **HUMONGOUS** interface, just for this one use. I'll trust GitHub's
+       * consistency and just type _my_ end, keeping theirs as `any`.
+       * <hr />
+       * @type {Array<repo>} mappedRepos - An array containing repository objects with mapped
+       * properties.
+       * @property {number} id - The unique identifier of the repository.
+       * @property {string} full_name - The full name of the repository.
+       * @property {string} html_url - The URL to the repository's page.
+       * @property {string | null} description - The description of the repository, or null if not provided.
+       * @property {boolean} private - A flag indicating whether the repository is private or public.
+       */
+        // eslint-disable-next-line
+      const mappedRepos: Array<repo> = jsonReposRes.map((repo: any): repo => ( {
+          id: repo.id,
+          full_name: repo.name,
+          html_url: repo.html_url,
+          description: repo.description,
+          private: repo.private,
+        } ));
+
+      setRepoList(mappedRepos);
       setUserData({
         login: jsonUserRes.login,
         name: jsonUserRes.name,
@@ -48,9 +85,12 @@ function App() {
         bio: jsonUserRes.bio,
       });
       setUserDataError(false);
+      setUserReposError(false);
 
     } catch (e) {
       setUserDataError(true);
+      setUserReposError(false);
+      setRepoList([]);
       console.error('Fetching error:', e);
 
     } finally {
@@ -58,15 +98,12 @@ function App() {
     }
   };
 
-  useEffect(() => {
-    console.log(userData);
-  }, [userData]);
-
   return (
     <>
       <Header/>
       <main className={styles.content}>
         <img src={github} alt="Github logo" className={styles.background}/>
+
         <div className={styles.info}>
           <div className={styles.search}>
             <Input value={userInput} onChange={handleChange}/>
@@ -89,7 +126,9 @@ function App() {
             )
           }
 
-          <RepoList/>
+          {!userReposError && !isLoading && <RepoList repos={repoList}/>}
+
+
         </div>
       </main>
     </>

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -5,6 +5,7 @@ import { Input } from '../../components/Input';
 import { Button } from '../../components/Button';
 import { useState } from 'react';
 import { Profile } from '../../components/Profile';
+import { RepoList } from '../../components/RepoList';
 
 function App() {
   const [counter, setCounter] = useState<number>(0);
@@ -27,6 +28,7 @@ function App() {
           <p>The 'search' button was clicked {counter} times.</p>
           <Profile />
           <hr />
+          <RepoList />
         </div>
       </main>
     </>


### PR DESCRIPTION
### Description

This pull request introduces several new features and improvements to the Home page of the application:

- **GitHub user search functionality**: Users can search for GitHub profiles by username, with proper handling for loading states and API errors. Search results dynamically update the Profile and RepoList components.
- **Repository data fetching**: Repositories are now fetched from the GitHub API, including support for displaying private/public indicators and descriptions. The structure is type-safe with a new `repo` type definition.
- **New components and styling**: Added `RepoList` and `RepoListItem` components for efficient display of repositories with enhanced CSS styling using modules. Simplified and standardized styles for better accessibility and UI structure.
- **Reusable components**: Introduced a `Loading` component and updated the `Input` component for improved user experience.
